### PR TITLE
Reconnect + Game version

### DIFF
--- a/source/nn/socket.hpp
+++ b/source/nn/socket.hpp
@@ -24,4 +24,5 @@ namespace nn::socket {
     s32 Bind(s32 socket, const sockaddr* addr, u32 addrLen);
     s32 Listen(s32 socket, s32 backlog);
     s32 Accept(s32 socket, sockaddr* addrOut, u32* addrLenOut);
+    s32 Shutdown(s32 desc, s32 how);
 };

--- a/source/program/main.cpp
+++ b/source/program/main.cpp
@@ -272,6 +272,11 @@ HOOK_DEFINE_TRAMPOLINE(LuaRegisterGlobals) {
     static void Callback(lua_State* L) {
         Orig(L);
         
+        nn::oe::DisplayVersion dispVer;
+        nn::oe::GetDisplayVersion(&dispVer);
+        lua_pushstring(L, dispVer.displayVersion);
+        lua_setglobal(L, "GameVersion");
+
         lua_pushcfunction(L, luaopen_debug);
         lua_pushstring(L, "debug");
         lua_call(L, 1, 0);

--- a/source/program/remote_api.cpp
+++ b/source/program/remote_api.cpp
@@ -69,9 +69,9 @@ void CreateServerSocket() {
         return;
     }
 
-    /* Set socket to keep-alive. */
-    // int flags = true;
-    // nn::socket::SetSockOpt(g_TcpSocket, SOL_SOCKET, SO_KEEPALIVE, &flags, sizeof(flags));
+    /* Set socket to reuse addr. On sleep mode, connection lost etc. this will make it reconnectable immediately. */
+    int flags = true;
+    nn::socket::SetSockOpt(g_TcpSocket, SOL_SOCKET, SO_REUSEADDR, &flags, sizeof(flags));
 
     /* Open and wait for connection. */
     struct sockaddr_in serverAddr;

--- a/source/program/remote_api.cpp
+++ b/source/program/remote_api.cpp
@@ -59,10 +59,15 @@ void PrepareThread() {
 
     void* pool = aligned_alloc(0x4000, SocketPoolSize);
     R_ABORT_UNLESS(nn::socket::Initialize(pool, SocketPoolSize, SocketAllocatorSize, 14));
+}
 
+void CreateServerSocket() {
     /* Open socket. */
     g_TcpSocket = nn::socket::Socket(AF_INET, SOCK_STREAM, IPPROTO_TCP);
-    if (g_TcpSocket < 0) EXL_ABORT(69);
+    if (g_TcpSocket < 0) {
+        g_TcpSocket = -1;
+        return;
+    }
 
     /* Set socket to keep-alive. */
     // int flags = true;
@@ -75,10 +80,18 @@ void PrepareThread() {
     serverAddr.sin_port = nn::socket::InetHtons(SocketPort);
 
     int rval = nn::socket::Bind(g_TcpSocket, (struct sockaddr*)&serverAddr, sizeof(serverAddr));
-    if (rval < 0) EXL_ABORT(69);
+    if (rval < 0) {
+        nn::socket::Close(g_TcpSocket);
+        g_TcpSocket = -1;
+        return;
+    }
 
     rval = nn::socket::Listen(g_TcpSocket, 1);
-    if (rval < 0) EXL_ABORT(69);
+    if (rval < 0) {
+        nn::socket::Close(g_TcpSocket);
+        g_TcpSocket = -1;
+        return;
+    }
 }
 
 void AddPacketToSendBuffer(PacketBuffer& buffer) {
@@ -111,7 +124,7 @@ void SendLogic() {
         }
     }
     // erase everything with size of 0
-    sendBuffer.erase(std::remove_if(sendBuffer.begin(), sendBuffer.end(), [](auto& pb) { 
+    sendBuffer.erase(std::remove_if(sendBuffer.begin(), sendBuffer.end(), [](auto& pb) {
         return pb->size() == 0;
     }),
                            sendBuffer.end());
@@ -124,33 +137,44 @@ void SocketSpawn(void *) {
 
     bool looping = true;
     while (looping) {
-        struct sockaddr clientAddr;
-        u32 addrLen;
-        requestNumber = 0;
-        memset(&RemoteApi::clientSubs, 0, sizeof(struct ClientSubscriptions));
-        clientSocket = nn::socket::Accept(g_TcpSocket, &clientAddr, &addrLen);
-        keepAlive = ResetValueAliveTimer;
-        while (looping) {
-            // poll every 2 ms = 2000000 ns
+        CreateServerSocket();
+        if (g_TcpSocket == -1) {
             svcSleepThread(2000000);
-            ReceiveLogic();
-            SendLogic();
+            continue;
+        }
+        while (looping) {
+            struct sockaddr clientAddr;
+            u32 addrLen;
+            requestNumber = 0;
+            memset(&RemoteApi::clientSubs, 0, sizeof(struct ClientSubscriptions));
+            clientSocket = nn::socket::Accept(g_TcpSocket, &clientAddr, &addrLen);
+            if (clientSocket < 0) break;
+            keepAlive = ResetValueAliveTimer;
+            while (looping) {
+                // poll every 2 ms = 2000000 ns
+                svcSleepThread(2000000);
+                ReceiveLogic();
+                SendLogic();
 
-            if (keepAlive == 0) {
-                // clean packet because there is no connection anymore
-                nn::os::LockMutex(&sendBufferLock);
-                svcSleepThread(100);
-                sendBuffer.clear();
-                nn::socket::Close(clientSocket);
-                clientSocket = -1;
-                nn::os::UnlockMutex(&sendBufferLock);
-                break;
+                if (keepAlive == 0) {
+                    // clean packet because there is no connection anymore
+                    nn::os::LockMutex(&sendBufferLock);
+                    svcSleepThread(100);
+                    sendBuffer.clear();
+                    nn::socket::Close(clientSocket);
+                    clientSocket = -1;
+                    nn::os::UnlockMutex(&sendBufferLock);
+                    break;
+                }
             }
         }
-    }
 
-    nn::socket::Close(g_TcpSocket);
-    svcExitThread();
+        if (g_TcpSocket != -1) {
+            nn::socket::Shutdown(g_TcpSocket, SHUT_RDWR);
+            nn::socket::Close(g_TcpSocket);
+            g_TcpSocket = -1;
+        }
+    }
 }
 
 void RemoteApi::Init() {

--- a/source/program/remote_api.hpp
+++ b/source/program/remote_api.hpp
@@ -22,6 +22,7 @@ enum PacketType {
     PACKET_COLLECTED_INDICES,
     PACKET_RECEIVED_PICKUPS,
     PACKET_GAME_STATE,
+    PACKET_MALFORMED,
 };
 
 enum ClientInterests {
@@ -42,4 +43,6 @@ class RemoteApi {
     static void ParseClientPacket();
     static void ParseHandshake();
     static void ParseRemoteLuaExec();
+    static void SendMalformedPacket();
+    static bool CheckReceivedBytes(ssize_t receivedBytes, int should);
 };


### PR DESCRIPTION
- Allow reconnect after switch console was in sleep mode
- Add GameVersion to lua globals

I removed the `EXL_ABORT` parts in the `listen`, `bind` part for the server socket. Just retry it until it works.
~~On a short wifi disconnect, it reconnected very fast for me.~~
~~On flight mode off/on toggle, it took something like 1 min to 3 min to reconnect :(~~
~~On sleep mode off/on toggle it reconnects within 25-40 seconds. (even when the switch was in sleep mode for a day).~~

~~I assume it works because it just relies on a timeout of the switch internals for the `bind` part of the port.~~

~~Sadly, I can not provide a better solution until someone tells me how to force the switch to release the listening ports.~~