### PR TITLE
Be able to receive lua code in chunks

### DIFF
--- a/source/program/remote_api.hpp
+++ b/source/program/remote_api.hpp
@@ -43,6 +43,6 @@ class RemoteApi {
     static void ParseClientPacket();
     static void ParseHandshake();
     static void ParseRemoteLuaExec();
-    static void SendMalformedPacket();
-    static bool CheckReceivedBytes(ssize_t receivedBytes, int should);
+    static void SendMalformedPacket(PacketType packet_type, ssize_t receivedBytes, int should);
+    static bool CheckReceivedBytes(PacketType packet_type, ssize_t receivedBytes, int should);
 };


### PR DESCRIPTION
Bootstrap code is like 3 packets where two hit the 4 kb limit of the buffer.
Sometimes on console (never for me on ryujinx) you receive less than the bytes sent by randovania which means you receive the 4 kb lua code in chunks.

Also added some infos if a packet is considered malformed which helped me to find this error.