### PR TITLE
Add feature that replaces item acquisition popups with "async messages"

### DIFF
--- a/source/program/dread_types.hpp
+++ b/source/program/dread_types.hpp
@@ -20,6 +20,15 @@ typedef struct {
 
     /** The lua_CFunction for `Game.LogWarn`, which is stubbed out in vanilla Dread. */
 	ptrdiff_t LogWarn;
+	ptrdiff_t CallFunctionWithArguments;
+
+	// Pickups
+    ptrdiff_t OnCollectPickup;
+	ptrdiff_t PlayPickupSound;
+    ptrdiff_t ShowItemPickupMessage;
+
+	// Audio
+	ptrdiff_t PlaySoundWithCallback;
 } functionOffsets;
 
 typedef unsigned long long crc64_t;

--- a/source/program/dread_types.hpp
+++ b/source/program/dread_types.hpp
@@ -21,3 +21,26 @@ typedef struct {
     /** The lua_CFunction for `Game.LogWarn`, which is stubbed out in vanilla Dread. */
 	ptrdiff_t LogWarn;
 } functionOffsets;
+
+typedef unsigned long long crc64_t;
+
+struct CRntString {
+	char* str;
+	int length;
+	void* allocator;
+	bool usesMainAllocator;
+	crc64_t hash;
+	bool isEmpty;
+};
+
+struct CStringInstance {
+	void* stringPoolEntry;
+	unsigned int uses;
+	CRntString string;
+	bool storeInPool;
+	unsigned int unknown;
+};
+
+struct CStrId {
+	CStringInstance *value;
+};

--- a/source/program/dread_types.hpp
+++ b/source/program/dread_types.hpp
@@ -20,14 +20,22 @@ typedef struct {
 
     /** The lua_CFunction for `Game.LogWarn`, which is stubbed out in vanilla Dread. */
 	ptrdiff_t LogWarn;
+
+	/** Used by the game engine to call a Lua function (by its qualified name) from C++ using varargs arguments. */
 	ptrdiff_t CallFunctionWithArguments;
 
 	// Pickups
+	/** Called when the player first collides with a Pickup item. */
     ptrdiff_t OnCollectPickup;
+
+	/** Called by the CPickableItemComponent class to play the appropriate sound for collecting a pickup. */
 	ptrdiff_t PlayPickupSound;
+
+	/** Called by the CPickableItemComponent class to show a pop-up dialog with a message for a newly-collected pickup. */
     ptrdiff_t ShowItemPickupMessage;
 
 	// Audio
+	/** Plays a sound effect with specific flags and a callback function that is invoked when the sound finishes playing. */
 	ptrdiff_t PlaySoundWithCallback;
 } functionOffsets;
 

--- a/source/program/item_pickups.cpp
+++ b/source/program/item_pickups.cpp
@@ -1,0 +1,135 @@
+#include "item_pickups.hpp"
+
+#include "lib.hpp"
+#include "lib/util/modules.hpp"
+#include "lua_helper.hpp"
+
+namespace odr::pickups {
+
+	static void QueueAsyncPopup(const char* message);
+	static void SoundCallbackHook(void* ptr1, void* ptr2, u32 param1, u32 param2);
+
+	static bool disableItemPopups = false;
+	static bool nextPopupIsAsync = false;
+	static bool hookNextSoundCallback = false;
+	static SoundCallbackFunction hookedCallback = NULL;
+
+	/**
+	 * Hooks the function that is called by CPickableItemComponent when the player picks up an item.
+	 * This function will call the "show item popup" function that we hook below, and we need the
+	 * next invocation of that to be handled by our hook.
+	 */
+	HOOK_DEFINE_TRAMPOLINE(OnCollectPickup) {
+		static void Callback(void* pickup, double d1, double d2, float f1, float f2) {
+			if (disableItemPopups) {
+				nextPopupIsAsync = true;
+			}
+
+			Orig(pickup, d1, d2, f1, f2);
+		}
+	};
+
+	/**
+	 * Hooks the function that is called by CPickableItemComponent to play its pickup sound.
+	 * We need to signal our hook for the "play sound" function to intercept the "sound completed"
+	 * callback, where we will manually restore environment music.
+	 */
+	HOOK_DEFINE_TRAMPOLINE(PlayPickupSound) {
+		static float Callback(void* pickup, u64 isKnownItem) {
+			if (nextPopupIsAsync) {
+				hookNextSoundCallback = true;
+			}
+
+			return Orig(pickup, isKnownItem);
+		}
+	};
+
+	/**
+	 * Hooks the function that shows the actual popup dialog when collecting an item.
+	 * When our "OnCollectPickup" hook above signals it, this hook will redirect the call to instead
+	 * queue an "async popup" similar to what is displayed when receiving items in a multiworld session.
+	 * In this case, this hook must immediately call the "popup dismissed" callback, as that callback
+	 * is responsible for some extra item pickup processing.
+	 */
+	HOOK_DEFINE_TRAMPOLINE(ShowItemPickupMessage) {
+		static void Callback(void* popupComposition, const CStrId* pickupMessage, PopupCallbackInfo* callbackInfo, double d1, double d2, float f1, float f2, bool flag, u32 u1) {
+			if (nextPopupIsAsync) {
+				nextPopupIsAsync = false;
+
+				// Show the pickup message at the top of the screen (like incoming multiworld items)
+				if (pickupMessage != NULL) {
+					const char* pickupMessageText = pickupMessage->value->string.str;
+
+					QueueAsyncPopup(pickupMessageText);
+				}
+
+				// Make sure to call the "after picked up" callback!
+				if (callbackInfo != NULL) {
+					// Dread calls the callback with values of "0.0, 0.0, 1.0f, 1.0f" in the vanilla game
+					callbackInfo->function(callbackInfo->receiver, 0.0, 0.0, 1.0f, 1.0f);
+				}
+
+				return;
+			}
+
+			Orig(popupComposition, pickupMessage, callbackInfo, d1, d2, f1, f2, flag, u1);
+		}
+	};
+
+	/**
+	 * Hooks the function responsible for playing certain sound effects and invoking a callback once the
+	 * sound has finished playing. When the "PlayPickupSound" hook signals it, this hook will intercept the
+	 * "sound completed" callback for a sound, and use it to queue the restoration of environmental music.
+	 * This task is normally performed by the "popup dismissed" callback above, but because that callback
+	 * is invoked immediately after the item is picked up in the case of our hooks, it tries to restore
+	 * music while the pickup sound is still playing (which does nothing). By waiting for the item sound
+	 * to finish playing, and then waiting an extra ~0.5 seconds, we can consistently restore music after
+	 * the sound plays.
+	 */
+	HOOK_DEFINE_TRAMPOLINE(PlaySoundWithCallback) {
+		static void Callback(void* musicManager, CRntString *soundName, u32 layer, u32 *flags, float param_5, float param_6, u32 param_7, u32 startTimeMs, SoundCallbackFunction callback) {
+			SoundCallbackFunction callbackToUse = callback;
+
+			if (hookNextSoundCallback) {
+				// Wrap callback with our own, so we can be notified when the sound finishes playing
+				hookNextSoundCallback = false;
+				hookedCallback = callback;
+				callbackToUse = SoundCallbackHook;
+			}
+
+			Orig(musicManager, soundName, layer, flags, param_5, param_6, param_7, startTimeMs, callbackToUse);
+		}
+	};
+
+};
+
+void odr::pickups::InstallHooks(const functionOffsets* offsets) {
+	OnCollectPickup::InstallAtOffset(offsets->OnCollectPickup);
+	PlayPickupSound::InstallAtOffset(offsets->PlayPickupSound);
+    ShowItemPickupMessage::InstallAtOffset(offsets->ShowItemPickupMessage);
+	PlaySoundWithCallback::InstallAtOffset(offsets->PlaySoundWithCallback);
+}
+
+int odr::pickups::SetItemPopupsEnabled(lua_State* L) {
+	if (lua_gettop(L) < 1) {
+		return luaL_error(L, "Expected a single boolean argument, but got none");
+	}
+
+	disableItemPopups = !lua_toboolean(L, 1);
+	return 0;
+}
+
+void odr::pickups::QueueAsyncPopup(const char* message) {
+	lua::CallFunctionWithArguments("Scenario.QueueAsyncPopup", "s", message);
+}
+
+void odr::pickups::SoundCallbackHook(void* ptr1, void* ptr2, u32 param1, u32 param2) {
+	if (hookedCallback != NULL) {
+		hookedCallback(ptr1, ptr2, param1, param2);
+		hookedCallback = NULL;
+	}
+
+	// After half a second, call the "PlayCurrentEnvironmentMusic" function to restore music after an item pickup sound plays.
+	// (for some reason, it doesn't work consistently if we just call it immediately in this hook)
+	lua::CallFunctionWithArguments("Game.AddGUISF", "fss", 0.5f, "Game.PlayCurrentEnvironmentMusic", "");
+}

--- a/source/program/item_pickups.cpp
+++ b/source/program/item_pickups.cpp
@@ -6,6 +6,11 @@
 
 namespace odr::pickups {
 
+	static const luaL_Reg luaLibrary[] = {
+		{"SetItemPopupsEnabled", SetItemPopupsEnabled},
+		{NULL, NULL},
+	};
+
 	static void QueueAsyncPopup(const char* message);
 	static void SoundCallbackHook(void* ptr1, void* ptr2, u32 param1, u32 param2);
 
@@ -108,6 +113,10 @@ void odr::pickups::InstallHooks(const functionOffsets* offsets) {
 	PlayPickupSound::InstallAtOffset(offsets->PlayPickupSound);
     ShowItemPickupMessage::InstallAtOffset(offsets->ShowItemPickupMessage);
 	PlaySoundWithCallback::InstallAtOffset(offsets->PlaySoundWithCallback);
+}
+
+void odr::pickups::InstallLuaLibrary(lua_State* L) {
+	luaL_register(L, "OdrPickups", luaLibrary);
 }
 
 int odr::pickups::SetItemPopupsEnabled(lua_State* L) {

--- a/source/program/item_pickups.hpp
+++ b/source/program/item_pickups.hpp
@@ -15,6 +15,7 @@ namespace odr::pickups {
 	};
 
 	void InstallHooks(const functionOffsets *offsets);
+	void InstallLuaLibrary(lua_State* L);
 	int SetItemPopupsEnabled(lua_State* L);
 
 };

--- a/source/program/item_pickups.hpp
+++ b/source/program/item_pickups.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "lib.hpp"
+#include "lua-5.1.5/src/lua.hpp"
+#include "dread_types.hpp"
+
+namespace odr::pickups {
+
+	typedef void (*PopupCallbackFunction)(void* receiver, double d1, double d2, float f1, float f2);
+	typedef void (*SoundCallbackFunction)(void* ptr1, void* ptr2, u32 param1, u32 param2);
+
+	struct PopupCallbackInfo {
+		void* receiver;
+		PopupCallbackFunction function;
+	};
+
+	void InstallHooks(const functionOffsets *offsets);
+	int SetItemPopupsEnabled(lua_State* L);
+
+};

--- a/source/program/lua_helper.cpp
+++ b/source/program/lua_helper.cpp
@@ -7,7 +7,7 @@ namespace odr::lua {
 
 };
 
-void odr::lua::InstallHooks(functionOffsets* offsets)  {
+void odr::lua::InstallFunctions(functionOffsets* offsets)  {
 	callFunctionWithArgumentsPtr = (bool(*)(const char*, const char*, ...)) exl::util::modules::GetTargetOffset(offsets->CallFunctionWithArguments);
 }
 

--- a/source/program/lua_helper.cpp
+++ b/source/program/lua_helper.cpp
@@ -1,0 +1,16 @@
+#include "lua_helper.hpp"
+#include "lib.hpp"
+
+namespace odr::lua {
+
+	static CallFunctionWithArgumentsFn callFunctionWithArgumentsPtr;
+
+};
+
+void odr::lua::InstallHooks(functionOffsets* offsets)  {
+	callFunctionWithArgumentsPtr = (bool(*)(const char*, const char*, ...)) exl::util::modules::GetTargetOffset(offsets->CallFunctionWithArguments);
+}
+
+odr::lua::CallFunctionWithArgumentsFn odr::lua::GetCallFunctionWithArgumentsPtr() {
+	return callFunctionWithArgumentsPtr;
+}

--- a/source/program/lua_helper.hpp
+++ b/source/program/lua_helper.hpp
@@ -10,7 +10,7 @@ namespace odr::lua {
 
 	typedef bool (*CallFunctionWithArgumentsFn)(const char *functionName, const char *argumentTypes, ...);
 
-	void InstallHooks(functionOffsets* offsets);
+	void InstallFunctions(functionOffsets* offsets);
 	CallFunctionWithArgumentsFn GetCallFunctionWithArgumentsPtr();
 
 	template <typename ...Params>

--- a/source/program/lua_helper.hpp
+++ b/source/program/lua_helper.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <utility>
+
+#include "lib/nx/kernel/svc.h"
+#include "lua-5.1.5/src/lua.hpp"
+#include "dread_types.hpp"
+
+namespace odr::lua {
+
+	typedef bool (*CallFunctionWithArgumentsFn)(const char *functionName, const char *argumentTypes, ...);
+
+	void InstallHooks(functionOffsets* offsets);
+	CallFunctionWithArgumentsFn GetCallFunctionWithArgumentsPtr();
+
+	template <typename ...Params>
+	bool CallFunctionWithArguments(const char* functionName, const char* argumentTypes, Params&&... params) {
+		CallFunctionWithArgumentsFn callFunctionWithArgumentsPtr = GetCallFunctionWithArgumentsPtr();
+
+		if (callFunctionWithArgumentsPtr == NULL) {
+			svcOutputDebugString("CallFunctionWithArguments could not be found!", 45);
+			return false;
+		}
+
+		return callFunctionWithArgumentsPtr(functionName, argumentTypes, std::forward<Params>(params)...);
+	}
+
+};

--- a/source/program/lua_helper.hpp
+++ b/source/program/lua_helper.hpp
@@ -13,6 +13,14 @@ namespace odr::lua {
 	void InstallFunctions(functionOffsets* offsets);
 	CallFunctionWithArgumentsFn GetCallFunctionWithArgumentsPtr();
 
+	/**
+	 * Calls the Lua function named `functionName` with zero or more arguments, whose types are indicated by the `argumentTypes` format string.
+	 * \param functionName The name of a Lua function. May be a compound name referring to a global object and function (e.g. `Game.LogWarn`).
+	 * \param argumentTypes A string containing one character per argument passed, representing the types of the arguments. The known supported
+	 * types are as follows: `b` - boolean, `i` - integer, `d` or `f` - float, `s` - string, `o` - unknown object type, `t` - Lua table,
+	 * `v` - vector (instance of `base::math::CVector3D`).
+	 * \param params Zero or more arguments, passed as variadic.
+	 */
 	template <typename ...Params>
 	bool CallFunctionWithArguments(const char* functionName, const char* argumentTypes, Params&&... params) {
 		CallFunctionWithArgumentsFn callFunctionWithArgumentsPtr = GetCallFunctionWithArgumentsPtr();

--- a/source/program/main.cpp
+++ b/source/program/main.cpp
@@ -361,7 +361,7 @@ extern "C" void exl_main(void* x0, void* x1)
     RomMounted::InstallAtFuncPtr(nn::fs::MountRom);
     LuaRegisterGlobals::InstallAtOffset(offsets.luaRegisterGlobals);
     odr::debug::InstallHooks(&offsets);
-    odr::lua::InstallHooks(&offsets);
+    odr::lua::InstallFunctions(&offsets);
     odr::pickups::InstallHooks(&offsets);
 
     /* Alternative install funcs: */

--- a/source/program/main.cpp
+++ b/source/program/main.cpp
@@ -7,6 +7,8 @@
 #include "lua-5.1.5/src/lua.hpp"
 #include "dread_types.hpp"
 #include "debug_hooks.hpp"
+#include "lua_helper.hpp"
+#include "item_pickups.hpp"
 
 typedef struct
 {
@@ -275,6 +277,11 @@ static const luaL_Reg multiworld_lib[] = {
   {NULL, NULL}
 };
 
+static const luaL_Reg odrpickups_lib[] = {
+    {"SetItemPopupsEnabled", odr::pickups::SetItemPopupsEnabled},
+    {NULL, NULL},
+};
+
 /* Hook asdf */
 
 HOOK_DEFINE_TRAMPOLINE(LuaRegisterGlobals) {
@@ -299,6 +306,7 @@ HOOK_DEFINE_TRAMPOLINE(LuaRegisterGlobals) {
         lua_setfield(L, -2, "BufferSize");
 
         odr::debug::InstallLuaLibrary(L);
+        luaL_register(L, "OdrPickups", odrpickups_lib);
     }
 };
 
@@ -315,6 +323,15 @@ void getVersionOffsets(functionOffsets *offsets)
         offsets->luaRegisterGlobals = 0x010aed50;
         offsets->lua_pcall = 0x010a3a80;
         offsets->LogWarn = 0x1094820;
+        offsets->CallFunctionWithArguments = 0x790; // wow that's early
+
+        // Pickups
+        offsets->OnCollectPickup = 0x9d0e28;
+        offsets->PlayPickupSound = 0x9d16c4;
+        offsets->ShowItemPickupMessage = 0xb5fd9c;
+
+        // Audio
+        offsets->PlaySoundWithCallback = 0xfd90d8;
     }
     else /* 1.0.0 - 2.0.0 */
     {
@@ -323,6 +340,15 @@ void getVersionOffsets(functionOffsets *offsets)
         offsets->luaRegisterGlobals = 0x106ce90;
         offsets->lua_pcall = 0x1061bc0;
         offsets->LogWarn = 0x1052a70;
+        offsets->CallFunctionWithArguments = 0x790;
+
+        // Pickups
+        offsets->OnCollectPickup = 0x9ce5c8;
+        offsets->PlayPickupSound = 0x9cee64;
+        offsets->ShowItemPickupMessage = 0xb5395c;
+
+        // Audio
+        offsets->PlaySoundWithCallback = 0xf975f8;
     }
 }
 
@@ -340,6 +366,8 @@ extern "C" void exl_main(void* x0, void* x1)
     RomMounted::InstallAtFuncPtr(nn::fs::MountRom);
     LuaRegisterGlobals::InstallAtOffset(offsets.luaRegisterGlobals);
     odr::debug::InstallHooks(&offsets);
+    odr::lua::InstallHooks(&offsets);
+    odr::pickups::InstallHooks(&offsets);
 
     /* Alternative install funcs: */
     /* InstallAtPtr takes an absolute address as a uintptr_t. */

--- a/source/program/main.cpp
+++ b/source/program/main.cpp
@@ -277,11 +277,6 @@ static const luaL_Reg multiworld_lib[] = {
   {NULL, NULL}
 };
 
-static const luaL_Reg odrpickups_lib[] = {
-    {"SetItemPopupsEnabled", odr::pickups::SetItemPopupsEnabled},
-    {NULL, NULL},
-};
-
 /* Hook asdf */
 
 HOOK_DEFINE_TRAMPOLINE(LuaRegisterGlobals) {
@@ -306,7 +301,7 @@ HOOK_DEFINE_TRAMPOLINE(LuaRegisterGlobals) {
         lua_setfield(L, -2, "BufferSize");
 
         odr::debug::InstallLuaLibrary(L);
-        luaL_register(L, "OdrPickups", odrpickups_lib);
+        odr::pickups::InstallLuaLibrary(L);
     }
 };
 


### PR DESCRIPTION
This adds several hooks to allow getting rid of item acquisition popups (i.e. the dialog prompt saying "Xyz acquired." that makes the player wait for several seconds before continuing), and replacing them with an "async message" that is displayed near the top of the screen without pausing gameplay (similar to multiworld items).

This is done by hooking several functions related to picking up an item. The hooks are documented via in-code comments, but I will explain the process here as well. The function names used are my own guesses based on what they seem to do.

### `OnCollectPickup`

This function is a vtable function for `CPickableItemComponent`, and it is called whenever the player first collides with a pickup. It is responsible for a number of things, including granting the item and incrementing max/current counts if necessary (e.g. missiles). Two of the things it does near the end of the function are triggering the "item pickup" sound, as well as displaying a GUI prompt informing the player that they have acquired an item.

This is hooked so that we can "flag" the next popup dialog as needing to be replaced (if the feature is enabled).

### `PlayPickupSound`

This function is also a vtable function for `CPickableItemComponent`. It is called by `OnCollectPickup` to determine the correct sound to play for the acquired item (as well as the correct vibration pattern), and then to play it. The function it uses to trigger the sound also accepts a callback that is called by the game once the sound finishes playing.

Normally, the game will fade out the environment music while it plays the pickup sound. The environment music is restored by the "dialog dismissed" callback. When a popup is skipped, we have to invoke the "dialog dismissed" callback _immediately after the item is picked up_, to handle some extra pickup logic (such as checkpoints, if enabled for that pickup). This "dialog dismissed" callback will attempt to restore environment music, except the item pickup sound will still be playing, so the music will not resume.

This function is hooked so that we can "flag" the next `PlaySoundWithCallback` invocation and intercept the "sound is done" callback with our own function. Our own function will call the intercepted one, and then manually restore environment music after a short delay.

### `ShowItemPickupMessage`

This function shows a GUI popup dialog containing the text provided by `CPickableItemComponent` for acquiring an item. The text is provided as a pointer to a `CStrId` instance. This function also accepts a struct representing a callback function that is called when the player dismisses the dialog, and a "receiver" object that will be passed to that callback.

This hook is the primary hook point for implementing this feature. If it is called after we have "flagged" the next popup as being skipped, it will completely skip calling the original function. Instead, it will queue an "async message" (exactly like how the multiworld connector queues them when receiving an item). The message will contain the exact text that would have displayed in the popup dialog. We also have to invoke the "dialog dismissed" callback immediately, so that any extra pickup logic performed by the game is not missed.

### `PlaySoundWithCallback`

This function is not specific to item pickups, but it is utilized by `CPickableItemComponent` in order to play the pickup sound and then be notified when the sound finishes playing.

The callback passed to this function by `CPickableItemComponent` is normally used to enable the dismissal of the "item acquired" dialog. The player is not allowed to dismiss it prior to the callback being invoked.

We "intercept" this callback for "async" items so that we can manually restore environment music once the pickup sound finishes playing. For some reason, simply attempting to play the environment music from inside this callback does not work consistently. Instead, we use `Game.AddGUISF` to start a 0.5-second timer, which will call `Game.PlayCurrentEnvironmentMusic` when it elapses, thus restoring the correct music.