### PR TITLE
Add toggleable "LogWarn" patch

### DIFF
--- a/source/program/debug_hooks.cpp
+++ b/source/program/debug_hooks.cpp
@@ -2,6 +2,11 @@
 
 namespace odr::debug {
 
+	static const luaL_Reg luaLibrary[] = {
+		{"SetLoggingEnabled", odr::debug::SetLoggingEnabled},
+		{NULL, NULL},
+	};
+
 	static bool loggingEnabled = false;
 
 	HOOK_DEFINE_REPLACE(LogWarn) {
@@ -30,6 +35,10 @@ namespace odr::debug {
 
 void odr::debug::InstallHooks(functionOffsets* offsets)  {
 	LogWarn::InstallAtOffset(offsets->LogWarn);
+}
+
+void odr::debug::InstallLuaLibrary(lua_State* L) {
+	luaL_register(L, "OdrDebug", luaLibrary);
 }
 
 int odr::debug::SetLoggingEnabled(lua_State *L) {

--- a/source/program/debug_hooks.cpp
+++ b/source/program/debug_hooks.cpp
@@ -15,9 +15,10 @@ namespace odr::debug {
 				return 0;
 			}
 
-			if (lua_gettop(L) < 2) {
-				svcOutputDebugString("Game.LogWarn: not enough arguments", 34);
-				return 0;
+			int nargs = lua_gettop(L);
+
+			if (nargs < 2) {
+				return luaL_error(L, "not enough arguments (expected 2, got %d)", nargs);
 			}
 
 			lua_Integer arg1 = lua_tointeger(L, 1);

--- a/source/program/debug_hooks.hpp
+++ b/source/program/debug_hooks.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <utility>
+
+#include "lib.hpp"
+#include "lib/nx/kernel/svc.h"
+#include "lua-5.1.5/src/lua.hpp"
+#include "dread_types.hpp"
+
+namespace odr::debug {
+	void InstallHooks(functionOffsets* offsets);
+	int SetLoggingEnabled(lua_State* L);
+};

--- a/source/program/debug_hooks.hpp
+++ b/source/program/debug_hooks.hpp
@@ -9,5 +9,6 @@
 
 namespace odr::debug {
 	void InstallHooks(functionOffsets* offsets);
+	void InstallLuaLibrary(lua_State* L);
 	int SetLoggingEnabled(lua_State* L);
 };

--- a/source/program/dread_types.hpp
+++ b/source/program/dread_types.hpp
@@ -7,4 +7,5 @@ typedef struct {
     ptrdiff_t CFilePathStrIdCtor;
     ptrdiff_t luaRegisterGlobals;
     ptrdiff_t lua_pcall;
+	ptrdiff_t LogWarn;
 } functionOffsets;

--- a/source/program/dread_types.hpp
+++ b/source/program/dread_types.hpp
@@ -1,0 +1,10 @@
+#pragma once
+
+#include <stddef.h>
+
+typedef struct {
+    ptrdiff_t crc64;
+    ptrdiff_t CFilePathStrIdCtor;
+    ptrdiff_t luaRegisterGlobals;
+    ptrdiff_t lua_pcall;
+} functionOffsets;

--- a/source/program/dread_types.hpp
+++ b/source/program/dread_types.hpp
@@ -2,10 +2,22 @@
 
 #include <stddef.h>
 
+/**
+ * Holds offset pointers for Dread functions that we either hook or call manually
+ */
 typedef struct {
+    /** Calculates the CRC64 hash of a string */
     ptrdiff_t crc64;
+
+    /** Constructor for `CFilePathStrId` class used when the game loads files */
     ptrdiff_t CFilePathStrIdCtor;
+
+    /** Function that registers Lua libraries (e.g. the `Game` library, etc.). Hooked to register our own. */
     ptrdiff_t luaRegisterGlobals;
+
+    /** Dread's custom lua_pcall function, used to call raw Lua code in protected mode */
     ptrdiff_t lua_pcall;
+
+    /** The lua_CFunction for `Game.LogWarn`, which is stubbed out in vanilla Dread. */
 	ptrdiff_t LogWarn;
 } functionOffsets;

--- a/source/program/main.cpp
+++ b/source/program/main.cpp
@@ -275,11 +275,6 @@ static const luaL_Reg multiworld_lib[] = {
   {NULL, NULL}
 };
 
-static const luaL_Reg odrdebug_lib[] = {
-    {"SetLoggingEnabled", odr::debug::SetLoggingEnabled},
-    {NULL, NULL},
-};
-
 /* Hook asdf */
 
 HOOK_DEFINE_TRAMPOLINE(LuaRegisterGlobals) {
@@ -303,7 +298,7 @@ HOOK_DEFINE_TRAMPOLINE(LuaRegisterGlobals) {
         lua_pushinteger(L, RemoteApi::BufferSize);
         lua_setfield(L, -2, "BufferSize");
 
-        luaL_register(L, "OdrDebug", odrdebug_lib);
+        odr::debug::InstallLuaLibrary(L);
     }
 };
 


### PR DESCRIPTION
This adds a hook for `Game.LogWarn` that, by default, does nothing. However, if the new `OdrDebug.SetLoggingEnabled` function is called from Lua with `true`, the hook will begin forwarding all `Game.LogWarn` messages to the `svcOutputDebugString` system call, which will appear in emulator consoles when "guest logs" are enabled. This makes it easy to enable and add debug logs for troubleshooting script problems, without needing to use RemoteLua to view logs.