### PR TITLE
Rename first save slot after seed hash

### DIFF
--- a/source/nn/fs/fs_types.hpp
+++ b/source/nn/fs/fs_types.hpp
@@ -20,6 +20,14 @@ namespace nn::fs {
         DirectoryEntryType_File,
     };
 
+    /*
+        Open a file.
+        outHandle:   Output for handle representing opened file.
+        path:        File path to open.
+        mode:        Mode to open file. See OpenMode.
+    */
+    Result GetEntryType(DirectoryEntryType* type_, char const* path);
+
     /* Bitfield to define the kinds of entries to open from a directory. */
     enum OpenDirectoryMode : u8 {
         OpenDirectoryMode_Directory = BIT(0),

--- a/source/program/dread_types.hpp
+++ b/source/program/dread_types.hpp
@@ -37,6 +37,12 @@ typedef struct {
 	// Audio
 	/** Plays a sound effect with specific flags and a callback function that is invoked when the sound finishes playing. */
 	ptrdiff_t PlaySoundWithCallback;
+
+	/** A large array of common CStrId in alpha order */
+	ptrdiff_t StaticStringBank;
+
+	/** Finds a StringInstance or creates one */
+	ptrdiff_t FindOrCreateStringInstance;
 } functionOffsets;
 
 typedef unsigned long long crc64_t;

--- a/source/program/main.cpp
+++ b/source/program/main.cpp
@@ -2,134 +2,16 @@
 #include "lib/util/modules.hpp"
 #include <nn.hpp>
 #include <cstring>
-#include "cJSON.h"
 #include "remote_api.hpp"
 #include "lua-5.1.5/src/lua.hpp"
 #include "dread_types.hpp"
 #include "debug_hooks.hpp"
 #include "lua_helper.hpp"
 #include "item_pickups.hpp"
-
-typedef struct
-{
-    u64 crc;
-    char const *replacement;
-} stringList;
-
-stringList *g_stringList = NULL;
-size_t g_stringListSize = 0;
-
-/* Function ptr to dread's crc function. */
-u64 (*crc64)(char const *str, u64 size) = NULL;
+#include "romfs.hpp"
 
 /* The main executable's pcall, so we get proper error handling. */
 int (*exefs_lua_pcall) (lua_State *L, int nargs, int nresults, int errfunc) = NULL;
-
-/* Takes in a pointer to string and if found in the list, is replaced with the desired string. */
-void replaceString(const char **str)
-{
-    /* Hash the string for quicker comparison. */
-    u64 crc = crc64(*str, strlen(*str));
-
-    /* Attempt to find matching hash in our list. */
-    for(size_t i = 0; i < g_stringListSize; i++)
-    {
-        /* If the string matches, replace the string. */
-        if(crc == g_stringList[i].crc)
-            *str = g_stringList[i].replacement;
-    }
-}
-
-HOOK_DEFINE_TRAMPOLINE(ForceRomfs) {
-    /* Define the callback for when the function is called. Don't forget to make it static and name it Callback. */
-    static void Callback(void *CFilePathStrIdOut, const char *path, u8 flags) {
-
-        /* Just in case the path is NULL, pass it down to the real implementation, since we don't support replacing NULL paths anyway. */
-        if(path == NULL)
-        {
-            Orig(CFilePathStrIdOut, path, flags);
-            return;
-        }
-
-        /* Replace string if we have it in our list before passing to the real implementation. */
-        replaceString(&path);
-        Orig(CFilePathStrIdOut, path, flags);
-    }
-};
-
-
-/* Allocates a buffer and reads from the specified file. */
-void *openAndReadFile(const char *path)
-{
-    long int size;
-    nn::fs::FileHandle fileHandle;
-    nn::fs::OpenFile(&fileHandle, path, nn::fs::OpenMode_Read);
-    nn::fs::GetFileSize(&size, fileHandle);
-    u8 *fileBuf = (u8 *)malloc(size + 1);
-    nn::fs::ReadFile(fileHandle, 0, fileBuf, size);
-    nn::fs::CloseFile(fileHandle);
-    fileBuf[size] = '\0';
-    return fileBuf;
-}
-
-void populateStringReplacementList()
-{
-    /* Read contents of replacements.json in romfs. Allocates a heap buffer for the file contents and returns it. */
-    char *fileBuf = (char *)openAndReadFile("rom:/replacements.json");
-
-    /* Parse json from file buffer. */
-    cJSON *json = cJSON_Parse(fileBuf);
-    if(json == NULL)
-        return;
-
-    /* Get the "replacements" object within the json. */
-    const cJSON *replacementList = cJSON_GetObjectItem(json, "replacements");
-
-    /* Get number of elements in the array, for later use. */
-    g_stringListSize = cJSON_GetArraySize(replacementList);
-
-    /* Allocate space for the list of strings to replace. */
-    g_stringList = (stringList *)malloc(g_stringListSize * sizeof(stringList));
-
-    size_t i = 0;
-    const cJSON *itemObject;
-
-    /* Iterate over array contents and extract strings. */
-    cJSON_ArrayForEach(itemObject, replacementList)
-    {
-        /* Extract the strings using the relevant method and add them to the list. */
-        if(cJSON_IsString(itemObject))
-        {
-            char *fileStr = cJSON_GetStringValue(itemObject);
-            char *replacementFileStr = (char *)malloc(strlen(fileStr) + strlen("rom:/") + 1);
-            strcpy(replacementFileStr, "rom:/");
-            replacementFileStr = strcat(replacementFileStr, fileStr);
-            g_stringList[i].crc = crc64(fileStr, strlen(fileStr));
-            g_stringList[i].replacement = replacementFileStr;
-        }
-        else if(cJSON_IsObject(itemObject))
-        {
-            char const *str = cJSON_GetItemName(itemObject);
-            g_stringList[i].crc = crc64(str, strlen(str));
-            g_stringList[i].replacement = cJSON_GetStringValue(itemObject->child);
-        }
-        i++;
-    }
-
-    /* Free the buffer allocated by openAndReadFile, since we're done with it. */
-    free(fileBuf);
-}
-
-/* Hook romfs mounting. Pass the arguments down to the real implementation so romfs is mounted as normal. */
-/* Once romfs is mounted, we can read files from it in order to populate our string replacement list. */
-HOOK_DEFINE_TRAMPOLINE(RomMounted) {
-    static Result Callback(char const *path, void *romCache, unsigned long cacheSize) {
-        Result res = Orig(path, romCache, cacheSize);
-        populateStringReplacementList();
-        return res;
-    }
-};
-
 
 void multiworld_schedule_update(lua_State* L) {
     lua_getglobal(L, "Game");
@@ -327,6 +209,10 @@ void getVersionOffsets(functionOffsets *offsets)
 
         // Audio
         offsets->PlaySoundWithCallback = 0xfd90d8;
+
+        // String bank
+        offsets->StaticStringBank = 0x1d552d0;
+        offsets->FindOrCreateStringInstance = 0x406dc;
     }
     else /* 1.0.0 - 2.0.0 */
     {
@@ -344,6 +230,10 @@ void getVersionOffsets(functionOffsets *offsets)
 
         // Audio
         offsets->PlaySoundWithCallback = 0xf975f8;
+
+        // String bank
+        offsets->StaticStringBank = 0x1cfc2d0;
+        offsets->FindOrCreateStringInstance = 0x4063c;
     }
 }
 
@@ -357,19 +247,17 @@ extern "C" void exl_main(void* x0, void* x1)
 
     /* Install the hook at the provided function pointer. Function type is checked against the callback function. */
     /* Hook functions we care about */
-    ForceRomfs::InstallAtOffset(offsets.CFilePathStrIdCtor);
-    RomMounted::InstallAtFuncPtr(nn::fs::MountRom);
     LuaRegisterGlobals::InstallAtOffset(offsets.luaRegisterGlobals);
     odr::debug::InstallHooks(&offsets);
     odr::lua::InstallFunctions(&offsets);
     odr::pickups::InstallHooks(&offsets);
+    odr::romfs::InstallHooks(&offsets);
 
     /* Alternative install funcs: */
     /* InstallAtPtr takes an absolute address as a uintptr_t. */
     /* InstallAtOffset takes an offset into the main module. */
 
     /* Get the address of dread's crc64 function */
-    crc64 = (u64 (*)(char const *, u64))exl::util::modules::GetTargetOffset(offsets.crc64);
     exefs_lua_pcall = (int (*) (lua_State *L, int nargs, int nresults, int errfunc)) exl::util::modules::GetTargetOffset(offsets.lua_pcall);
 }
 

--- a/source/program/romfs.cpp
+++ b/source/program/romfs.cpp
@@ -36,7 +36,9 @@ void replaceString(const char **str)
     }
 }
 
-/* Allocates a buffer and reads from the specified file. */
+/* Allocates a buffer and reads from the specified file.
+ * If the path is not a valid file entry, immediately returns NULL.
+ * Caller is expected to free any non-NULL return value. */
 void* odr::romfs::OpenAndReadFile(const char *path)
 {
     nn::fs::DirectoryEntryType entryType;
@@ -56,6 +58,8 @@ void* odr::romfs::OpenAndReadFile(const char *path)
     return fileBuf;
 }
 
+/* Parses rom:/replacements.json and populates g_stringList.
+ * If replacements.json does not exist, logs a warning and returns without modifying values. */
 void populateStringReplacementList()
 {
     /* Read contents of replacements.json in romfs. Allocates a heap buffer for the file contents and returns it. */
@@ -109,6 +113,16 @@ void populateStringReplacementList()
     free(fileBuf);
 }
 
+/* Sets the save slot names based on the string in "rom:/RDVHASH". 
+ * The file must contain at most a 253-character string (called "hash"). 
+ * If rom:/RDVHASH is not a valid file, writes a warning to console and returns without modifying strings.
+ * If rom:/RDVHASH has a string that is too long, writes a warning to console and returns without modifying strings.
+ *
+ * The following strings are changed:
+ *
+ *  - "profile0" -> "hash_0"
+ *  - "profile1" -> "hash_1"
+ *  - "profile2" -> "hash_2" */
 void setSeedSaveProfile()
 {
     char *seedHash = (char*)odr::romfs::OpenAndReadFile("rom:/RDVHASH");
@@ -119,22 +133,30 @@ void setSeedSaveProfile()
     }
 
     int len = strlen(seedHash);
+    if (len > 253)
+    {
+        const char* msg = "[LogWarn/0] requested slot name in rom:/RDVHASH must be shorter than 254 characters!";
+        svcOutputDebugString(msg, strlen(msg));
+        return;
+    }
+
     if (len > 0)
     {
         char slotName[256];
         u64 crc;
+        len += 2;
 
-        sprintf(slotName, "%s0", seedHash);
-        crc = crc64(slotName, len+1);
-        create_string_instance(&g_stringBank[odr::romfs::STRINGBANK_PROFILE0], slotName, len+1, crc, true);
+        sprintf(slotName, "%s_0", seedHash);
+        crc = crc64(slotName, len);
+        create_string_instance(&g_stringBank[odr::romfs::STRINGBANK_PROFILE0], slotName, len, crc, true);
 
-        slotName[len] = '1';
-        crc = crc64(slotName, len+1);
-        create_string_instance(&g_stringBank[odr::romfs::STRINGBANK_PROFILE0+1], slotName, len+1, crc, true);
+        slotName[len-1] = '1';
+        crc = crc64(slotName, len);
+        create_string_instance(&g_stringBank[odr::romfs::STRINGBANK_PROFILE0+1], slotName, len, crc, true);
 
-        slotName[len] = '2';
-        crc = crc64(slotName, len+1);
-        create_string_instance(&g_stringBank[odr::romfs::STRINGBANK_PROFILE0+2], slotName, len+1, crc, true);
+        slotName[len-1] = '2';
+        crc = crc64(slotName, len);
+        create_string_instance(&g_stringBank[odr::romfs::STRINGBANK_PROFILE0+2], slotName, len, crc, true);
     }
     free(seedHash);
     return;

--- a/source/program/romfs.cpp
+++ b/source/program/romfs.cpp
@@ -1,0 +1,177 @@
+#include "romfs.hpp"
+
+#include <nn.hpp>
+#include "lib.hpp"
+#include "cJSON.h"
+
+typedef struct
+{
+    u64 crc;
+    char const *replacement;
+} stringList;
+
+/* Function ptr to dread's crc function. */
+u64 (*crc64)(char const *str, u64 size) = NULL;
+
+stringList *g_stringList = NULL;
+size_t g_stringListSize = 0;
+
+CStrId* g_stringBank = NULL;
+
+/** Create a string instance */
+void (*create_string_instance) (CStrId* value, const char* str, uint len, u64 crc, bool storeInPool) = NULL;
+
+/* Takes in a pointer to string and if found in the list, is replaced with the desired string. */
+void replaceString(const char **str)
+{
+    /* Hash the string for quicker comparison. */
+    u64 crc = crc64(*str, strlen(*str));
+
+    /* Attempt to find matching hash in our list. */
+    for(size_t i = 0; i < g_stringListSize; i++)
+    {
+        /* If the string matches, replace the string. */
+        if(crc == g_stringList[i].crc)
+            *str = g_stringList[i].replacement;
+    }
+}
+
+/* Allocates a buffer and reads from the specified file. */
+void* odr::romfs::OpenAndReadFile(const char *path)
+{
+    nn::fs::DirectoryEntryType entryType;
+    nn::fs::GetEntryType(&entryType, path);
+    if (entryType != nn::fs::DirectoryEntryType_File) {
+        return NULL;
+    }
+
+    long int size;
+    nn::fs::FileHandle fileHandle;
+    nn::fs::OpenFile(&fileHandle, path, nn::fs::OpenMode_Read);
+    nn::fs::GetFileSize(&size, fileHandle);
+    u8 *fileBuf = (u8 *)malloc(size + 1);
+    nn::fs::ReadFile(fileHandle, 0, fileBuf, size);
+    nn::fs::CloseFile(fileHandle);
+    fileBuf[size] = '\0';
+    return fileBuf;
+}
+
+void populateStringReplacementList()
+{
+    /* Read contents of replacements.json in romfs. Allocates a heap buffer for the file contents and returns it. */
+    char *fileBuf = (char *)odr::romfs::OpenAndReadFile("rom:/replacements.json");
+    if (fileBuf == NULL) {
+        const char* msg = "[LogWarn/0] rom:/replacements.json does not exist!";
+        svcOutputDebugString(msg, strlen(msg));
+        return;
+    }
+
+    /* Parse json from file buffer. */
+    cJSON *json = cJSON_Parse(fileBuf);
+    if(json == NULL)
+        return;
+
+    /* Get the "replacements" object within the json. */
+    const cJSON *replacementList = cJSON_GetObjectItem(json, "replacements");
+
+    /* Get number of elements in the array, for later use. */
+    g_stringListSize = cJSON_GetArraySize(replacementList);
+
+    /* Allocate space for the list of strings to replace. */
+    g_stringList = (stringList *)malloc(g_stringListSize * sizeof(stringList));
+
+    size_t i = 0;
+    const cJSON *itemObject;
+
+    /* Iterate over array contents and extract strings. */
+    cJSON_ArrayForEach(itemObject, replacementList)
+    {
+        /* Extract the strings using the relevant method and add them to the list. */
+        if(cJSON_IsString(itemObject))
+        {
+            char *fileStr = cJSON_GetStringValue(itemObject);
+            char *replacementFileStr = (char *)malloc(strlen(fileStr) + strlen("rom:/") + 1);
+            strcpy(replacementFileStr, "rom:/");
+            replacementFileStr = strcat(replacementFileStr, fileStr);
+            g_stringList[i].crc = crc64(fileStr, strlen(fileStr));
+            g_stringList[i].replacement = replacementFileStr;
+        }
+        else if(cJSON_IsObject(itemObject))
+        {
+            char const *str = cJSON_GetItemName(itemObject);
+            g_stringList[i].crc = crc64(str, strlen(str));
+            g_stringList[i].replacement = cJSON_GetStringValue(itemObject->child);
+        }
+        i++;
+    }
+
+    /* Free the buffer allocated by OpenAndReadFile, since we're done with it. */
+    free(fileBuf);
+}
+
+void setSeedSaveProfile()
+{
+    char *seedHash = (char*)odr::romfs::OpenAndReadFile("rom:/RDVHASH");
+    if (seedHash == NULL) {
+        const char* msg = "[LogWarn/0] rom:/RDVHASH does not exist!";
+        svcOutputDebugString(msg, strlen(msg));
+        return;
+    }
+
+    int len = strlen(seedHash);
+    if (len > 0)
+    {
+        char slotName[256];
+        u64 crc;
+
+        sprintf(slotName, "%s0", seedHash);
+        crc = crc64(slotName, len+1);
+        create_string_instance(&g_stringBank[odr::romfs::STRINGBANK_PROFILE0], slotName, len+1, crc, true);
+
+        slotName[len] = '1';
+        crc = crc64(slotName, len+1);
+        create_string_instance(&g_stringBank[odr::romfs::STRINGBANK_PROFILE0+1], slotName, len+1, crc, true);
+
+        slotName[len] = '2';
+        crc = crc64(slotName, len+1);
+        create_string_instance(&g_stringBank[odr::romfs::STRINGBANK_PROFILE0+2], slotName, len+1, crc, true);
+    }
+    free(seedHash);
+    return;
+}
+
+HOOK_DEFINE_TRAMPOLINE(ForceRomfs) {
+    /* Define the callback for when the function is called. Don't forget to make it static and name it Callback. */
+    static void Callback(void *CFilePathStrIdOut, const char *path, u8 flags) {
+
+        /* Just in case the path is NULL, pass it down to the real implementation, since we don't support replacing NULL paths anyway. */
+        if(path == NULL)
+        {
+            Orig(CFilePathStrIdOut, path, flags);
+            return;
+        }
+
+        /* Replace string if we have it in our list before passing to the real implementation. */
+        replaceString(&path);
+        Orig(CFilePathStrIdOut, path, flags);
+    }
+};
+
+/* Hook romfs mounting. Pass the arguments down to the real implementation so romfs is mounted as normal. */
+/* Once romfs is mounted, we can read files from it in order to populate our string replacement list. */
+HOOK_DEFINE_TRAMPOLINE(RomMounted) {
+    static Result Callback(char const *path, void *romCache, unsigned long cacheSize) {
+        Result res = Orig(path, romCache, cacheSize);
+        populateStringReplacementList();
+        setSeedSaveProfile();
+        return res;
+    }
+};
+
+void odr::romfs::InstallHooks(functionOffsets* offsets) {
+    RomMounted::InstallAtFuncPtr(nn::fs::MountRom);
+    ForceRomfs::InstallAtOffset(offsets->CFilePathStrIdCtor);
+    crc64 = (u64 (*)(char const *, u64))exl::util::modules::GetTargetOffset(offsets->crc64);
+    create_string_instance = (void (*)(CStrId* value, const char* str, uint len, u64 crc, bool storeInPool)) exl::util::modules::GetTargetOffset(offsets->FindOrCreateStringInstance);
+    g_stringBank = (CStrId*)exl::util::modules::GetTargetOffset(offsets->StaticStringBank);
+}

--- a/source/program/romfs.hpp
+++ b/source/program/romfs.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include "common.hpp"
+#include "dread_types.hpp"
+
+namespace odr::romfs {
+    void InstallHooks(functionOffsets* offsets);
+    void* OpenAndReadFile(const char* path);
+
+    /** The offset of "profile0" in the string bank. "profile1" and "profile2" immediately proceed. */
+    const int STRINGBANK_PROFILE0 = 917;
+}


### PR DESCRIPTION
Expects a new file `rom:/RDVHASH`, which is just a string containing a seed hash (or theoretically anything). This replaces `profile0` in the static string bank in memory, which effectively replaces the first save slot ("profile0") with a seed-specific hash. 

I also moved a lot of the romfs code to a new source/header file because main is fairly bloated at this point. Probably better ways to organize it but i'm not very familiar with this repo or c++ project structures. I feel like crc64 could maybe be extracted to a `common.cpp` or something, not sure. 

Tested on 1.0.0 and 2.1.0. Would probably want this to go through a full month of RDV beta testing when we have a corresponding ODR/RDV patch ready, since i'm not confident it won't break anything lmao. 